### PR TITLE
Removed Udp.flush()

### DIFF
--- a/MK312Wifi/MK312Wifi.ino
+++ b/MK312Wifi/MK312Wifi.ino
@@ -448,8 +448,7 @@ void handleUDP() {
       Udp.write(ip[1]);
       Udp.write(ip[2]);
       Udp.write(ip[3]);
-      Udp.flush();
-      Udp.endPacket();
+      Udp.endPacket(); // "flush" the output as we're sending the packet UDP now
     }
   }
 


### PR DESCRIPTION
I wrote a detection routine in Python based on the UDP broadcast packet mechanism, and i had some trouble because the MK312WIFI was replying with two packets (the second one being empty). The workaround is easy, but I still fixed the problem by removing the `Udp.flush()` line, function which is just doing another call to `WiFiUDP::endPacket()` on the ESP8266WiFi library. No need to flush the output buffer, as the packet is sent when `Udp.endPacket()` is called. 

- [WiFiUdp.cpp line 228 from ESP8266WiFi library](https://github.com/esp8266/Arduino/blob/master/libraries/ESP8266WiFi/src/WiFiUdp.cpp#L228)
- [Inconsitent meaning of WiFiUDP::flush() across cores](https://github.com/esp8266/Arduino/issues/8312)

Note: on ESP32, the `WiFiUDP::flush()` function is just discarding any data left in the inbound buffer.